### PR TITLE
Add vertical_form wrapper to add the labels on top of the form inputs

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -124,7 +124,7 @@ ul {
 }
 
 .navbar a.active {
-  color: white;
+  color: rgb(253, 251, 252);
 }
 
 .page {
@@ -145,5 +145,31 @@ ul {
 }
 
 .darkmode a {
-  color: white;
+  color: var(--text-color)
+}
+
+.darkmode a:hover{
+  color: var(--base-variant)
+}
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.form-control {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.invalid-feedback {
+  color: red;
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
 }

--- a/app/assets/stylesheets/update_user.css
+++ b/app/assets/stylesheets/update_user.css
@@ -3,31 +3,17 @@
   text-align: center;
 }
 
-.form-inputs {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.5rem;
-  width: 100%;
-}
-
-.edit-page {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  min-height: 100vh;
-  padding: 0;
-}
-
 .account-actions {
   display: flex;
   flex-direction: column;
   text-align: center;
+  margin-top: 2.5rem;
+  gap: .625rem;
 }
 
 .edit-user-container {
   display: flex;
+  margin-top: 3.125rem;
 }
 
 .edit-form-container {
@@ -50,6 +36,27 @@
 }
 
 .bio-text-box {
-  height: 17px;
-  width: 146px;
+  height: 26px;
+  width: 166px;
+}
+
+.forms {
+  display: flex;
+  gap: 2rem;
+  margin-bottom: 2rem;
+  margin-left: 2rem;
+}
+
+.left-forms,
+.right-forms {
+  width: 50%;
+  height: 100%;
+}
+
+.form-footer {
+  display: flex;
+  flex-direction: column;
+  width: auto;
+  align-items: center;
+  text-align: center;
 }

--- a/app/assets/stylesheets/users.css
+++ b/app/assets/stylesheets/users.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 100vh;
+  /* height: 100vh; */
 }
 
 .profile-header {

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -22,45 +22,63 @@
           </div>
 
           <div class="forms">
-            <%= f.input :bio,
+            <div class="left-forms">
+              <%= f.input :bio,
                 required: false,
                 autofocus: true,
+                wrapper: :vertical_form,
                 input_html: {class: "bio-text-box"}
                 %>
-            <%= f.input :email,
+              <%= f.input :email,
                 required: true,
                 autofocus: true,
+                wrapper: :vertical_form,
                 input_html: { autocomplete: "email" }%>
-            <%= f.input :name,
+              <%= f.input :name,
+                wrapper: :vertical_form,
                 required: true
                 %>
-            <%= f.input :username,
+              <%= f.input :username,
                 required: true,
+                wrapper: :vertical_form,
                 autofocus: true
                 %>
-            <%= f.input :address,
-                required: true,
-                autofocus: true
-                %>
-            <%= f.input :location,
-                required: true,
-                autofocus: true
-                %>
-            <%= f.input :password,
-                required: false,
-                input_html: { autocomplete: "new-password" } %>
-            <%= f.input :password_confirmation,
-                required: false,
-                input_html: { autocomplete: "new-password" } %>
-            <%= f.input :current_password,
-                required: true,
-                input_html: { autocomplete: "current-password" } %>
-            <div class="form-actions">
-              <%= f.button :submit, "Update", class: "boxBtn" %>
             </div>
-          <% end %>
+
+            <div class="right-forms">
+              <%= f.input :address,
+                required: true,
+                wrapper: :vertical_form,
+                autofocus: true
+                %>
+              <%= f.input :location,
+                required: true,
+                wrapper: :vertical_form,
+                autofocus: true
+                %>
+              <%= f.input :password,
+                required: false,
+                wrapper: :vertical_form,
+                input_html: { autocomplete: "new-password" } %>
+              <%= f.input :password_confirmation,
+                required: false,
+                wrapper: :vertical_form,
+                input_html: { autocomplete: "new-password" } %>
+            </div>
+          </div>
         </div>
+
+        <div class="form-footer">
+                <%= f.input :current_password,
+                required: true,
+                wrapper: :vertical_form,
+                input_html: { autocomplete: "current-password" } %>
+          <div class="form-actions">
+            <%= f.button :submit, "Update", class: "boxBtn" %>
+          </div>
       </div>
+
+      <% end %>
     </div>
 
     <div class="account-actions">

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -13,6 +13,14 @@ SimpleForm.setup do |config|
   # wrapper, change the order or even add your own to the
   # stack. The options given below are used to wrap the
   # whole input.
+  config.wrappers :vertical_form, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.use :label, wrap_with: { tag: :label, class: 'form-label' }
+    b.use :input, class: 'form-control'
+    b.use :error, wrap_with: { tag: :div, class: 'invalid-feedback' }
+    b.use :hint,  wrap_with: { tag: :small, class: 'form-text text-muted' }
+  end
   config.wrappers :default, class: :input,
     hint_class: :field_with_hint, error_class: :field_with_errors, valid_class: :field_without_errors do |b|
     ## Extensions enabled by default

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -73,7 +73,7 @@ SimpleForm.setup do |config|
   end
 
   # The default wrapper to be used by the FormBuilder.
-  config.default_wrapper = :default
+  config.default_wrapper = :vertical_form
 
   # Define the way to render check boxes / radio buttons with labels.
   # Defaults to :nested for bootstrap config.


### PR DESCRIPTION
- Add wrapper: :vertical_form to each of the form inputs on the edit user page
- Update the styling of the edit user page for a cleaner ui
- Update the dark mode's styling for enhanced user experience and accessibility